### PR TITLE
feat: Comprehensive CapSheet sharing data preservation

### DIFF
--- a/src/services/capSheetSharingService.js
+++ b/src/services/capSheetSharingService.js
@@ -24,7 +24,10 @@ export const createShareableLink = async (capSheetData) => {
       data: {
         hitters: capSheetData.hitters?.map(sanitizePlayerData) || [],
         pitchers: capSheetData.pitchers?.map(sanitizePlayerData) || [],
-        handicappers: capSheetData.handicappers || [],
+        handicappers: {
+          hitters: capSheetData.handicappers?.hitters || [],
+          pitchers: capSheetData.handicappers?.pitchers || []
+        },
         settings: {
           hitterGamesHistory: capSheetData.settings?.hitterGamesHistory || 3,
           pitcherGamesHistory: capSheetData.settings?.pitcherGamesHistory || 3,
@@ -34,6 +37,8 @@ export const createShareableLink = async (capSheetData) => {
       summary: {
         totalHitters: capSheetData.hitters?.length || 0,
         totalPitchers: capSheetData.pitchers?.length || 0,
+        totalHitterHandicappers: capSheetData.handicappers?.hitters?.length || 0,
+        totalPitcherHandicappers: capSheetData.handicappers?.pitchers?.length || 0,
         totalHandicappers: (capSheetData.handicappers?.hitters?.length || 0) + (capSheetData.handicappers?.pitchers?.length || 0),
         createdAt: new Date().toISOString()
       }
@@ -107,24 +112,99 @@ const createGitHubGist = async (shareData) => {
  * Create Base64 encoded share link (fallback method)
  */
 const createBase64Share = async (shareData) => {
-  // Compress the data for URL sharing
+  // Compress the data for URL sharing with comprehensive field preservation
   const compressedData = {
     v: shareData.version,
     c: shareData.created,
     d: {
       h: shareData.data.hitters.map(h => ({
+        // Basic info (short keys for compression)
         n: h.name,
         t: h.team,
         p: h.position,
         b: h.bats,
-        g: h.games
+        fn: h.fullName,
+        
+        // Game data
+        g: h.games,
+        lhr: h.lastHR,
+        lab: h.lastAB,
+        lh: h.lastH,
+        thr: h.totalHR,
+        
+        // Critical custom fields
+        eso: h.expectedSO,
+        gou: h.gameOU,
+        std: h.stadium,
+        pit: h.pitcher,
+        pid: h.pitcherId,
+        ph: h.pitcherHand,
+        opp: h.opponent,
+        opt: h.opponentTeam,
+        
+        // Bet types
+        bt: h.betTypes,
+        
+        // Handicapper data
+        hc: h.handicappers,
+        hp: h.handicapperPicks,
+        
+        // Game history (preserve all game fields)
+        ...Object.fromEntries(
+          Object.entries(h).filter(([key, value]) => 
+            key.startsWith('game') && value !== undefined && value !== null && value !== ''
+          )
+        ),
+        
+        // Previous game stats
+        ...Object.fromEntries(
+          Object.entries(h).filter(([key, value]) => 
+            key.startsWith('prevGame') && value !== undefined && value !== null && value !== ''
+          )
+        )
       })),
       p: shareData.data.pitchers.map(p => ({
+        // Basic info
         n: p.name,
         t: p.team,
         th: p.throwingArm,
-        g: p.games
+        pit: p.pitches,
+        fn: p.fullName,
+        
+        // Game data
+        g: p.games,
+        era: p.ERA,
+        whip: p.WHIP,
+        
+        // Critical custom fields
+        ek: p.expectedK,
+        ep: p.expectedPitch,
+        gou: p.gameOU,
+        std: p.stadium,
+        opp: p.opponent,
+        
+        // Bet types
+        bt: p.betTypes,
+        
+        // Handicapper data
+        hc: p.handicappers,
+        hp: p.handicapperPicks,
+        
+        // Game history (preserve all game fields)
+        ...Object.fromEntries(
+          Object.entries(p).filter(([key, value]) => 
+            key.startsWith('game') && value !== undefined && value !== null && value !== ''
+          )
+        ),
+        
+        // Previous game stats
+        ...Object.fromEntries(
+          Object.entries(p).filter(([key, value]) => 
+            key.startsWith('prevGame') && value !== undefined && value !== null && value !== ''
+          )
+        )
       })),
+      hcp: shareData.data.handicappers,
       s: shareData.data.settings
     },
     s: shareData.summary
@@ -132,9 +212,10 @@ const createBase64Share = async (shareData) => {
 
   const jsonString = JSON.stringify(compressedData);
   
-  // Check if data is too large for URL
-  if (jsonString.length > 2000) {
-    throw new Error('CapSheet too large for URL sharing. Try reducing the number of players.');
+  // Check if data is too large for URL - increased limit for comprehensive data
+  if (jsonString.length > 8000) {
+    console.warn('[CapSheetSharing] Base64 data size:', jsonString.length, 'characters');
+    throw new Error('CapSheet too large for URL sharing. Please use the GitHub Gist option instead.');
   }
 
   const encoded = btoa(jsonString);
@@ -143,7 +224,7 @@ const createBase64Share = async (shareData) => {
   // Generate a pseudo-ID for consistency
   const shareId = 'base64_' + Date.now().toString(36);
 
-  console.log('[CapSheetSharing] Base64 share created:', shareId);
+  console.log('[CapSheetSharing] Base64 share created:', shareId, 'Size:', jsonString.length, 'chars');
 
   return {
     url: shareUrl,
@@ -227,18 +308,96 @@ export const loadBase64CapSheet = async (encodedData) => {
       created: compressedData.c,
       data: {
         hitters: compressedData.d.h.map(h => ({
+          // Basic info
           name: h.n,
           team: h.t,
-          position: h.p,
-          bats: h.b,
-          games: h.g
+          position: h.p || h.position,
+          bats: h.b || h.bats,
+          fullName: h.fn || h.fullName,
+          
+          // Game data
+          games: h.g || h.games,
+          lastHR: h.lhr || h.lastHR,
+          lastAB: h.lab || h.lastAB,
+          lastH: h.lh || h.lastH,
+          totalHR: h.thr || h.totalHR,
+          
+          // Critical custom fields
+          expectedSO: h.eso || h.expectedSO,
+          gameOU: h.gou || h.gameOU,
+          stadium: h.std || h.stadium,
+          pitcher: h.pit || h.pitcher,
+          pitcherId: h.pid || h.pitcherId,
+          pitcherHand: h.ph || h.pitcherHand,
+          opponent: h.opp || h.opponent,
+          opponentTeam: h.opt || h.opponentTeam,
+          
+          // Bet types
+          betTypes: h.bt || h.betTypes || {},
+          
+          // Handicapper data
+          handicappers: h.hc || h.handicappers,
+          handicapperPicks: h.hp || h.handicapperPicks || {},
+          
+          // Game history - preserve all available fields
+          ...Object.fromEntries(
+            Object.entries(h).filter(([key, value]) => 
+              key.startsWith('game') && value !== undefined
+            )
+          ),
+          
+          // Previous game stats
+          ...Object.fromEntries(
+            Object.entries(h).filter(([key, value]) => 
+              key.startsWith('prevGame') && value !== undefined
+            )
+          )
         })),
         pitchers: compressedData.d.p.map(p => ({
+          // Basic info
           name: p.n,
           team: p.t,
-          throwingArm: p.th,
-          games: p.g
+          throwingArm: p.th || p.throwingArm,
+          pitches: p.pit || p.pitches,
+          fullName: p.fn || p.fullName,
+          
+          // Game data
+          games: p.g || p.games,
+          ERA: p.era || p.ERA,
+          WHIP: p.whip || p.WHIP,
+          
+          // Critical custom fields
+          expectedK: p.ek || p.expectedK,
+          expectedPitch: p.ep || p.expectedPitch,
+          gameOU: p.gou || p.gameOU,
+          stadium: p.std || p.stadium,
+          opponent: p.opp || p.opponent,
+          
+          // Bet types
+          betTypes: p.bt || p.betTypes || {},
+          
+          // Handicapper data
+          handicappers: p.hc || p.handicappers,
+          handicapperPicks: p.hp || p.handicapperPicks || {},
+          
+          // Game history - preserve all available fields
+          ...Object.fromEntries(
+            Object.entries(p).filter(([key, value]) => 
+              key.startsWith('game') && value !== undefined
+            )
+          ),
+          
+          // Previous game stats
+          ...Object.fromEntries(
+            Object.entries(p).filter(([key, value]) => 
+              key.startsWith('prevGame') && value !== undefined
+            )
+          )
         })),
+        handicappers: compressedData.d.hcp || compressedData.d.handicappers || {
+          hitters: [],
+          pitchers: []
+        },
         settings: compressedData.d.s
       },
       summary: compressedData.s
@@ -278,30 +437,106 @@ const sanitizePlayerData = (player) => {
     position,
     bats,
     throwingArm,
+    pitches, // For pitchers
+    fullName,
+    
     // Game statistics
     games,
     lastHR,
     lastAB, 
     lastH,
     totalHR,
+    
+    // Critical CapSheet custom fields
+    expectedSO, // Expected strikeouts for hitters
+    expectedK,  // Expected strikeouts for pitchers
+    expectedPitch, // Expected pitch count for pitchers
+    gameOU,     // Over/Under values
+    stadium,    // Stadium selection
+    pitcher,    // Assigned pitcher for hitters
+    pitcherId,  // Pitcher ID
+    pitcherHand, // Pitcher handedness
+    opponent,   // Opponent team
+    opponentTeam, // Opponent team (alternative field)
+    
+    // Bet types (critical for sharing)
+    betTypes,
+    
     // Handicapper data
     handicappers,
+    handicapperPicks,
+    
+    // Game history data (up to 7 games)
+    game1Date, game1HR, game1AB, game1H, game1IP, game1K, game1ER, game1BB, game1PC_ST,
+    game2Date, game2HR, game2AB, game2H, game2IP, game2K, game2ER, game2BB, game2PC_ST,
+    game3Date, game3HR, game3AB, game3H, game3IP, game3K, game3ER, game3BB, game3PC_ST,
+    game4Date, game4HR, game4AB, game4H, game4IP, game4K, game4ER, game4BB, game4PC_ST,
+    game5Date, game5HR, game5AB, game5H, game5IP, game5K, game5ER, game5BB, game5PC_ST,
+    game6Date, game6HR, game6AB, game6H, game6IP, game6K, game6ER, game6BB, game6PC_ST,
+    game7Date, game7HR, game7AB, game7H, game7IP, game7K, game7ER, game7BB, game7PC_ST,
+    
+    // Previous game statistics
+    prevGameHR, prevGameAB, prevGameH, prevGameIP, prevGameK, prevGameER, prevGameBB, prevGamePC_ST,
+    
+    // Additional pitcher stats
+    ERA, WHIP,
+    
     // Other relevant data
     ...otherData
   } = player;
 
   return {
+    // Basic player info
     name,
     team,
     position,
     bats,
     throwingArm,
+    pitches,
+    fullName,
+    
+    // Game statistics
     games,
     lastHR,
     lastAB,
     lastH,
     totalHR,
+    
+    // Critical CapSheet custom fields
+    expectedSO,
+    expectedK,
+    expectedPitch,
+    gameOU,
+    stadium,
+    pitcher,
+    pitcherId,
+    pitcherHand,
+    opponent,
+    opponentTeam,
+    
+    // Bet types
+    betTypes,
+    
+    // Handicapper data
     handicappers,
+    handicapperPicks,
+    
+    // Game history data
+    game1Date, game1HR, game1AB, game1H, game1IP, game1K, game1ER, game1BB, game1PC_ST,
+    game2Date, game2HR, game2AB, game2H, game2IP, game2K, game2ER, game2BB, game2PC_ST,
+    game3Date, game3HR, game3AB, game3H, game3IP, game3K, game3ER, game3BB, game3PC_ST,
+    game4Date, game4HR, game4AB, game4H, game4IP, game4K, game4ER, game4BB, game4PC_ST,
+    game5Date, game5HR, game5AB, game5H, game5IP, game5K, game5ER, game5BB, game5PC_ST,
+    game6Date, game6HR, game6AB, game6H, game6IP, game6K, game6ER, game6BB, game6PC_ST,
+    game7Date, game7HR, game7AB, game7H, game7IP, game7K, game7ER, game7BB, game7PC_ST,
+    
+    // Previous game statistics
+    prevGameHR, prevGameAB, prevGameH, prevGameIP, prevGameK, prevGameER, prevGameBB, prevGamePC_ST,
+    
+    // Additional pitcher stats
+    ERA,
+    WHIP,
+    
     // Include other data but be selective
     ...Object.fromEntries(
       Object.entries(otherData).filter(([key, value]) => 
@@ -324,32 +559,73 @@ const sanitizePlayerData = (player) => {
 const generateShareReadme = (shareData) => {
   const { summary, data } = shareData;
   
+  // Count players with various data types
+  const hittersWithBets = data.hitters.filter(h => h.betTypes && (h.betTypes.H || h.betTypes.HR || h.betTypes.B)).length;
+  const pitchersWithBets = data.pitchers.filter(p => p.betTypes && (p.betTypes.K || p.betTypes.OU)).length;
+  const hittersWithCustomData = data.hitters.filter(h => h.expectedSO || h.gameOU || h.pitcher || h.stadium).length;
+  const pitchersWithCustomData = data.pitchers.filter(p => p.expectedK || p.expectedPitch || p.gameOU || p.opponent || p.stadium).length;
+  
   return `# CapSheet Share - Capping.Pro
 
-**Created:** ${new Date(shareData.created).toLocaleString()}
-**Source:** ${shareData.source}
+**Created:** ${new Date(shareData.created).toLocaleString()}  
+**Source:** ${shareData.source}  
+**Version:** ${shareData.version}
 
 ## Summary
-- **${summary.totalHitters}** Hitters
-- **${summary.totalPitchers}** Pitchers  
-- **${summary.totalHandicappers}** Handicappers
+- **${summary.totalHitters}** Hitters (${hittersWithBets} with bet types, ${hittersWithCustomData} with custom data)
+- **${summary.totalPitchers}** Pitchers (${pitchersWithBets} with bet types, ${pitchersWithCustomData} with custom data)
+- **${summary.totalHitterHandicappers || 0}** Hitter Handicappers
+- **${summary.totalPitcherHandicappers || 0}** Pitcher Handicappers
 - **Games History:** ${data.settings?.hitterGamesHistory || 3} games (hitters), ${data.settings?.pitcherGamesHistory || 3} games (pitchers)
+- **Date Context:** ${data.settings?.currentDate || 'Current'}
+
+## Data Included
+This comprehensive CapSheet share includes:
+
+### For Hitters:
+- Basic player info (name, team, position, batting hand)
+- Game history (up to ${data.settings?.hitterGamesHistory || 3} games)
+- Custom fields: Expected SO, Game O/U, Assigned Pitcher, Stadium
+- Bet types: Hits (H), Home Runs (HR), Bases (B)
+- Handicapper picks and analysis
+
+### For Pitchers:
+- Basic player info (name, team, throwing arm, pitch types)
+- Game history (up to ${data.settings?.pitcherGamesHistory || 3} games)
+- Custom fields: Expected K, Expected Pitch Count, Game O/U, Opponent, Stadium
+- Bet types: Strikeouts (K), Over/Under (OU)
+- Handicapper picks and analysis
 
 ## How to Use
 1. Copy the share URL from the CapSheet application
 2. Share the URL with others
 3. Recipients can load the CapSheet by visiting the URL
+4. All custom data, bet selections, and handicapper picks will be preserved
 
 ## Players Included
 
 ### Hitters (${summary.totalHitters})
-${data.hitters.map(h => `- ${h.name} (${h.team})`).join('\n')}
+${data.hitters.map(h => {
+  const bets = h.betTypes ? Object.entries(h.betTypes).filter(([_, selected]) => selected).map(([type, _]) => type).join(', ') : '';
+  const customInfo = [h.expectedSO && `ExpSO: ${h.expectedSO}`, h.gameOU && `O/U: ${h.gameOU}`, h.pitcher && `vs ${h.pitcher}`].filter(Boolean).join(' | ');
+  return `- **${h.name}** (${h.team})${bets ? ` - Bets: ${bets}` : ''}${customInfo ? ` - ${customInfo}` : ''}`;
+}).join('\n')}
 
 ### Pitchers (${summary.totalPitchers})
-${data.pitchers.map(p => `- ${p.name} (${p.team})`).join('\n')}
+${data.pitchers.map(p => {
+  const bets = p.betTypes ? Object.entries(p.betTypes).filter(([_, selected]) => selected).map(([type, _]) => type).join(', ') : '';
+  const customInfo = [p.expectedK && `ExpK: ${p.expectedK}`, p.expectedPitch && `ExpPC: ${p.expectedPitch}`, p.gameOU && `O/U: ${p.gameOU}`].filter(Boolean).join(' | ');
+  return `- **${p.name}** (${p.team})${bets ? ` - Bets: ${bets}` : ''}${customInfo ? ` - ${customInfo}` : ''}`;
+}).join('\n')}
+
+${summary.totalHitterHandicappers > 0 || summary.totalPitcherHandicappers > 0 ? `
+## Handicappers Included
+${summary.totalHitterHandicappers > 0 ? `- **${summary.totalHitterHandicappers}** Hitter Handicappers` : ''}
+${summary.totalPitcherHandicappers > 0 ? `- **${summary.totalPitcherHandicappers}** Pitcher Handicappers` : ''}
+` : ''}
 
 ## About CapSheet
-CapSheet is a comprehensive baseball handicapping tool from Capping.Pro that helps analyze player performance and make informed betting decisions.
+CapSheet is a comprehensive baseball handicapping tool from Capping.Pro that helps analyze player performance and make informed betting decisions. This share preserves all your custom data, selections, and analysis.
 
 **Visit:** https://capping.pro
 `;


### PR DESCRIPTION
ISSUE FIXED: Expected strikeouts, over/under, pitchers, and handicappers data was not being fully captured in shared CapSheets.

Changes made:
- Enhanced sanitizePlayerData() to explicitly preserve all critical fields:
  * expectedSO, expectedK, expectedPitch (strikeout/pitch expectations)
  * gameOU (over/under values)
  * pitcher, pitcherId, pitcherHand (pitcher assignments)
  * betTypes (all bet type selections)
  * handicapperPicks (all handicapper data)
  * Full game history (up to 7 games)
  * Previous game statistics
  * Stadium, opponent, and other custom fields

- Fixed Base64 compression/decompression to preserve all custom fields:
  * Updated createBase64Share() to include all critical data with compressed keys
  * Enhanced loadBase64CapSheet() to restore all fields properly
  * Increased size limit from 2KB to 8KB for comprehensive data
  * Added fallback mapping for both compressed and full field names

- Improved handicapper data structure consistency:
  * Fixed handicappers data structure to properly separate hitters/pitchers
  * Enhanced summary reporting with detailed counts
  * Better error handling for handicapper data

- Enhanced README generation for shared Gists:
  * Shows detailed breakdown of players with custom data
  * Displays bet types and custom field information
  * More comprehensive sharing documentation

This fix ensures that ALL user-customizable CapSheet data is preserved during sharing, including expected strikeouts, over/under values, pitcher assignments, bet types, and handicapper selections.

🤖 Generated with [Claude Code](https://claude.ai/code)