### PR TITLE
Fix hardcoded paths for deployment portability

### DIFF
--- a/generate_enhanced_weakspot_exploiters.py
+++ b/generate_enhanced_weakspot_exploiters.py
@@ -14,8 +14,13 @@ import re
 from collections import defaultdict
 
 class EnhancedWeakspotAnalyzer:
-    def __init__(self, base_path="/Users/futurepr0n/Development/Capping.Pro/Claude-Code/BaseballTracker", target_date=None):
-        self.base_path = Path(base_path)
+    def __init__(self, base_path=None, target_date=None):
+        # Use current working directory if no base_path provided
+        # This makes it work from any deployment location
+        if base_path is None:
+            self.base_path = Path.cwd()
+        else:
+            self.base_path = Path(base_path)
         self.stats_path = self.base_path / "public/data/stats"
         self.data_path = self.base_path / "public/data"
         self.target_date = target_date or datetime.now().strftime('%Y-%m-%d')


### PR DESCRIPTION
- Replace hardcoded dev machine path with relative Path.cwd()
- Enables deployment to any location (/app/BaseballTracker on server)
- Maintains backward compatibility with optional base_path override